### PR TITLE
fix: fixed styling issue in homepage showing unfriendly enum

### DIFF
--- a/app/src/components/BookCard.jsx
+++ b/app/src/components/BookCard.jsx
@@ -264,7 +264,11 @@ const BookCard = ({ book, isHome }) => {
           <div className="flex justify-between items-center">
             <div>
               <p className="text-sm text-gray-500">Status</p>
-              <p className="text-sm capitalize">{book.status || "Available"}</p>
+              <p className="text-sm capitalize">
+                {book.status === "forRent"
+                  ? "Available for rent"
+                  : "Closed by uploader/Currently rented"}
+              </p>
             </div>
 
             <div className="text-right">

--- a/app/src/components/HomePage/FilterBar.jsx
+++ b/app/src/components/HomePage/FilterBar.jsx
@@ -51,9 +51,20 @@ export const FilterBar = ({
 
         <FilterDropdown
           label="Status"
-          options={["available", "rented", "unavailable"]}
-          activeOption={activeFilters.status}
-          onSelect={(value) => handleFilterChange("status", value)}
+          options={["Available", "Unavailable"]}
+          activeOption={
+            activeFilters.status
+              ? activeFilters.status === "forRent"
+                ? "Available"
+                : "Unavailable"
+              : null
+          }
+          onSelect={(value) =>
+            handleFilterChange(
+              "status",
+              value === "Available" ? "forRent" : "isClosed"
+            )
+          }
           onClear={() => clearFilter("status")}
         />
 


### PR DESCRIPTION
replaced unfriendly 'forRent' and 'isClosed' with a more friendly 'Available' and 'Unavailable' option on the filter and bookcard